### PR TITLE
fix: Always bump all crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holochain_release_util"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/integration/src/lib.rs
+++ b/crates/integration/src/lib.rs
@@ -525,6 +525,8 @@ edition.workspace = true
             .arg("--yes")
             .arg("custom")
             .arg(version.trim_start_matches('v'))
+            .arg("--force")
+            .arg("*")
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit())
             .spawn()

--- a/crates/release_util/Cargo.toml
+++ b/crates/release_util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_release_util"
-version = "0.1.1"
+version = "0.1.2"
 description = "Utility crate for Holochain release management"
 edition.workspace = true
 license.workspace = true

--- a/crates/release_util/src/prepare_release.rs
+++ b/crates/release_util/src/prepare_release.rs
@@ -76,7 +76,9 @@ pub(crate) fn set_version(dir: impl AsRef<Path>, version: &str) -> anyhow::Resul
         .arg("--no-git-commit")
         .arg("--yes")
         .arg("custom")
-        .arg(version);
+        .arg(version)
+        .arg("--force")
+        .arg("*");
 
     let status = command
         .status()


### PR DESCRIPTION
The alternative doesn't actually make sense when we're versioning in lockstep across a workspace. As soon as you do an incompatible version bump and workspaces chooses to only update the version of changed crates, it will fail to build.

Problem workflow https://github.com/holochain/wind-tunnel/actions/runs/15755505065