### PR TITLE
Add direnv support to use Nix devShell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
+watch_file rust-toolchain.toml
+
 use flake

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.87.0"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]


### PR DESCRIPTION
This PR adds support for direnv to use the Nix devShell. It also adds `rust-analyzer` and `rust-src` to the Rust toolchain components which allows the devShell to use the LSP that matches the correct Rust version.