### PR TITLE
fix: else-if syntax

### DIFF
--- a/pre-1.0-cliff.toml
+++ b/pre-1.0-cliff.toml
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 body = """
 {% if version -%}
     ## \\[[{{ version | trim_start_matches(pat="v") }}](https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/{% if previous.version -%}compare/{{ previous.version }}...{% else -%}commits/{% endif -%}{{ version }})\\] - {{ timestamp | date(format="%Y-%m-%d") }}
-{% elseif previous.version -%}
+{% elif previous.version -%}
     ## \\[[Unreleased](https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/compare/{{ previous.version }}...HEAD)\\]
 {% else -%}
     ## \\[Unreleased\\]


### PR DESCRIPTION
Tera templates used by git-cliff use `elif` instead of `elseif`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected changelog logic so the “Unreleased” header displays correctly when a prior version exists, ensuring consistent formatting and preventing missing/incorrect headers. No changes to other sections.

* **Chores**
  * Minor maintenance to release process configuration to improve reliability of release notes generation; no impact on application features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->