### PR TITLE
fix(cliff): add the tag_pattern to ignore non-release tags

### DIFF
--- a/pre-1.0-cliff.toml
+++ b/pre-1.0-cliff.toml
@@ -82,6 +82,8 @@ filter_commits = false
 topo_order = false
 # Show the newest commits in each section first
 sort_commits = "newest"
+# The Regex to use to select which tags count as release tags
+tag_pattern = "^v?[0-9]+\\.[0-9]+\\.[0-9]+"
 
 [bump]
 # Want to use a `v` prefix, so set the initial tag and git-cliff will respect it after that


### PR DESCRIPTION
Currently, all tags are matched and added to the changelog but that breaks the `--bump` logic of git-cliff because it takes a tag like `main-<sha>` and doesn't know how to bump it. With this change any unmatched tags are ignored and the commits under it are added to the next valid commit, that means that given the following:

```mermaid
gitGraph:
       commit id: "1"
       commit id: "2" tag: "main-2"
       commit id: "3"
       commit id: "4" tag: "v0.1.0"
       commit id: "5"
```

Commits `1`, `2`, `3`, and `4` are all added to the changelog under the `v0.1.0` tag. Then, if running with `--bump` then a new entry will be added to the changelog with commit `5` under `v0.1.1`.