### PR TITLE
chore: update tooling versions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
     environment:
       - USER_UID=1000
       - USER_GID=1000
+      - GITEA__repository__ENABLE_PUSH_CREATE_USER=true
     volumes:
       - gitea:/data
       - /etc/timezone:/etc/timezone:ro

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772161521,
-        "narHash": "sha256-HmbcapTlcRqtryLUaJhH8t1mz6DaSJT+nxvWIl2bIPU=",
+        "lastModified": 1780543271,
+        "narHash": "sha256-oPJ7eJN1sM37v92Rp/eyQL7/rUm0BOvXEBAoq/zN0cM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9b2965450437541d25fde167d8bebfd01c156cef",
+        "rev": "c30ca201c5093540cf792f6982f81ba1aa0f3514",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,6 @@
                 cargo-semver-checks
                 gh
                 httpie
-                initool
                 perl
                 upx
               ];

--- a/scripts/setup_git.sh
+++ b/scripts/setup_git.sh
@@ -14,12 +14,3 @@ docker compose exec --user 1000:1000 gitea \
 docker compose exec --user 1000:1000 gitea \
   gitea admin user generate-access-token --username gituser --token-name test_token --scopes write:repository,read:user --raw > "$script_dir/git_test_token.txt"
 
-docker compose cp gitea:/data/gitea/conf/app.ini "$script_dir/app.ini"
-initool set "$script_dir/app.ini" repository ENABLE_PUSH_CREATE_USER true > "$script_dir/app.ini.new" \
-  && mv "$script_dir/app.ini.new" "$script_dir/app.ini"
-
-docker compose cp "$script_dir/app.ini" gitea:/data/gitea/conf/app.ini
-
-rm "$script_dir/app.ini"
-
-docker compose restart gitea


### PR DESCRIPTION
Perform a `nix flake update` to update all of the binary tools used by this project, things such as `git-cliff` and `cargo-semver-checks`.

I have tested it locally with the docker containers.

I have also enabled the `ENABLE_PUSH_CREATE_USER` option in Gitea via the docker compose environment variable instead of copying the `app.ini` file, modifying, and then copying back to the container.