### PR TITLE
fix: mark pre-release versions correctly on GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ There are a few important things to know when maintaining repositories that use 
 - Release tags are filtered by branch so that only tags that are relevant to the current branch are considered. This is 
   done to permit creating new releases from release branches, after newer versions have been published from the main 
   branch.
+- A pre-release version, such as `v0.5.0-dev.0`, is created as a pre-release on GitHub and is never marked as the latest 
+  release.
+- Any other version is only marked as the latest release on GitHub if it is higher than the version of the current 
+  latest release. This means that releasing `v0.3.7` from a release branch will not replace `v0.4.2` as the latest 
+  release. Note that GitHub would otherwise mark every new release as the latest one, regardless of its version.
 - Although the tool used to manage versions in `Cargo.toml` files (cargo-workspaces) is capable of understanding various
   strategies for versioning crates within a workspace, this tool only supports using a single version for all crates and
   it must be specified in the root `Cargo.toml` file. Use the `[workspace.package]` section to specify the version and 

--- a/crates/release_util/src/publish_release.rs
+++ b/crates/release_util/src/publish_release.rs
@@ -107,6 +107,80 @@ pub(crate) fn publish(dir: impl AsRef<Path>) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Parse the version from a release tag, which may or may not have a `v` prefix.
+fn parse_version_tag(tag: &str) -> anyhow::Result<semver::Version> {
+    semver::Version::parse(tag.trim_start_matches('v'))
+        .with_context(|| format!("Release tag is not a valid version: {tag}"))
+}
+
+/// Checks whether a release tag refers to a pre-release version.
+///
+/// Determined by the semver pre-release field, so any pre-release format is recognised, not just
+/// the `-dev.X` format that is currently used for Holochain releases.
+fn is_prerelease_tag(tag: &str) -> anyhow::Result<bool> {
+    Ok(!parse_version_tag(tag)?.pre.is_empty())
+}
+
+/// Get the tag of the repository's current latest release, if it has one.
+///
+/// Pre-releases and drafts are never the latest release, so they are not considered here.
+fn get_latest_release_tag(dir: impl AsRef<Path>) -> anyhow::Result<Option<String>> {
+    let output = std::process::Command::new("gh")
+        .current_dir(dir)
+        .arg("release")
+        .arg("view")
+        .arg("--json")
+        .arg("tagName")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .context("Failed to run `gh release view`")?;
+
+    // The command fails when the repository has no releases yet, which is not an error here.
+    if !output.status.success() {
+        println!("No current latest release found, this release will become the latest.");
+        return Ok(None);
+    }
+
+    let value = serde_json::from_slice::<serde_json::Value>(&output.stdout)
+        .context("Failed to parse `gh release view` output")?;
+
+    Ok(Some(
+        value
+            .as_object()
+            .context("Expected a JSON object as release view output")?
+            .get("tagName")
+            .context("Missing 'tagName' in release data")?
+            .as_str()
+            .context("Expected the tag name to be a string")?
+            .to_string(),
+    ))
+}
+
+/// Checks whether a release tag should become the repository's latest release.
+///
+/// GitHub marks every new release as the latest one unless told otherwise, which is wrong when
+/// releasing from a release branch after a newer version has been released from another branch.
+/// For example, releasing `v0.3.7` when `v0.4.2` is already out should leave `v0.4.2` as the
+/// latest release.
+fn should_be_latest_release(tag: &str, current_latest_tag: Option<&str>) -> anyhow::Result<bool> {
+    let version = parse_version_tag(tag)?;
+
+    let Some(current_latest_tag) = current_latest_tag else {
+        return Ok(true);
+    };
+
+    // Only the tag being released has to be a valid version. If the current latest release was not
+    // created by this tool, then leave it to GitHub to decide what the latest release should be.
+    match parse_version_tag(current_latest_tag) {
+        Ok(current_latest_version) => Ok(version > current_latest_version),
+        Err(e) => {
+            println!("Ignoring the current latest release: {e:?}");
+            Ok(true)
+        }
+    }
+}
+
 pub(crate) fn create_gh_release(dir: impl AsRef<Path>, tag: &str) -> anyhow::Result<()> {
     let repository_name = std::env::var("GITHUB_REPOSITORY")
         .context("Missing environment variable `GITHUB_REPOSITORY`")?
@@ -117,8 +191,10 @@ pub(crate) fn create_gh_release(dir: impl AsRef<Path>, tag: &str) -> anyhow::Res
 
     let tag_version = tag.trim_start_matches('v');
 
-    std::process::Command::new("gh")
-        .current_dir(dir)
+    let mut command = std::process::Command::new("gh");
+
+    command
+        .current_dir(&dir)
         .arg("release")
         .arg("create")
         .arg(tag)
@@ -126,9 +202,90 @@ pub(crate) fn create_gh_release(dir: impl AsRef<Path>, tag: &str) -> anyhow::Res
         .arg("--title")
         .arg(format!("{} {}", repository_name, tag_version))
         .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit());
+
+    if is_prerelease_tag(tag)? {
+        println!("Creating {} as a pre-release", tag);
+        // GitHub will not select a pre-release as the latest release, but say so explicitly rather
+        // than relying on that.
+        command.arg("--prerelease").arg("--latest=false");
+    } else {
+        let current_latest_tag = get_latest_release_tag(&dir)?;
+        if !should_be_latest_release(tag, current_latest_tag.as_deref())? {
+            println!(
+                "Creating {} without making it the latest release, {} is newer",
+                tag,
+                current_latest_tag.unwrap_or_default()
+            );
+            command.arg("--latest=false");
+        }
+    }
+
+    let status = command
         .status()
         .context("Failed to create GitHub release")?;
 
+    if !status.success() {
+        anyhow::bail!(
+            "Failed to create GitHub release, gh exited with: {}",
+            status
+        );
+    }
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_tag_is_not_a_prerelease() {
+        assert!(!is_prerelease_tag("v1.2.3").unwrap());
+    }
+
+    #[test]
+    fn dev_tag_is_a_prerelease() {
+        assert!(is_prerelease_tag("v1.2.3-dev.0").unwrap());
+    }
+
+    #[test]
+    fn rc_tag_is_a_prerelease() {
+        assert!(is_prerelease_tag("v1.2.3-rc.1").unwrap());
+    }
+
+    #[test]
+    fn build_metadata_alone_is_not_a_prerelease() {
+        assert!(!is_prerelease_tag("v1.2.3+build.5").unwrap());
+    }
+
+    #[test]
+    fn tag_without_v_prefix_is_accepted() {
+        assert!(is_prerelease_tag("1.2.3-dev.0").unwrap());
+    }
+
+    #[test]
+    fn tag_that_is_not_semver_is_rejected() {
+        assert!(is_prerelease_tag("vnot-a-version").is_err());
+    }
+
+    #[test]
+    fn newer_release_becomes_latest() {
+        assert!(should_be_latest_release("v0.4.3", Some("v0.4.2")).unwrap());
+    }
+
+    #[test]
+    fn patch_for_an_older_release_line_does_not_become_latest() {
+        assert!(!should_be_latest_release("v0.3.7", Some("v0.4.2")).unwrap());
+    }
+
+    #[test]
+    fn first_release_of_a_repository_becomes_latest() {
+        assert!(should_be_latest_release("v0.1.0", None).unwrap());
+    }
+
+    #[test]
+    fn unrecognised_current_latest_release_leaves_the_release_as_latest() {
+        assert!(should_be_latest_release("v1.0.0", Some("nightly")).unwrap());
+    }
 }


### PR DESCRIPTION
## Summary
- Pre-release versions, such as `v0.5.0-dev.0`, are now created as pre-releases on GitHub and are never marked as the latest release.
- Other versions are only marked as the latest release when they are higher than the version of the current latest release. This stops a patch release from a release branch, such as `v0.3.7`, from replacing a newer release, such as `v0.4.2`, as the latest release. GitHub marks every new release as the latest one by default, regardless of its version, so this needs to be requested explicitly.
- The exit status of the GitHub CLI is now checked when creating a release. It was previously ignored, so a failed release creation was reported as a successful release.
- Added unit tests for tag classification and the latest release comparison, and documented the behaviour in the maintainers section of the README.

## Notes
- The pre-release and latest decisions are separated into pure functions, so they are unit tested. The `gh` invocation itself has no automated coverage, since the integration tests run against Gitea and skip GitHub release creation.
- Flag behaviour was checked against `gh release create --help` and the REST API documentation for `make_latest`.